### PR TITLE
Update to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,11 @@ You only need to do it once.
     ```text
     contains(https://www.googleapis.com/auth/photos.native)
     ```
+    or
+    ```text
+    contains(www.googleapis.com%2Fauth%2Fplus.photos.readwrite)
+    ```
+
 
 5. Open Google Photos app and login with your account.
 6. There should be a single request found.  


### PR DESCRIPTION
Tried with multiple emulators and versions of photos app, was not able to intercept any requests with .../photos.native or the intercepted auth returns 403. Had to get request with `www.googleapis.com%2Fauth%2Fplus.photos.readwrite` for it to work. 

Tested on: Android Studio emulator - Android 11 (Google API image)
Photos app version: 4.52.0.316821695 (Stock photos app included in ADV)